### PR TITLE
Pulling GameBoard classes: ToolMakerHutField, PlaceOnToolMakeAdaptor, PlaceOnHutAdaptor, PlaceOnFieldsAdaptor

### DIFF
--- a/ToolMakerHutFields.java
+++ b/ToolMakerHutFields.java
@@ -1,0 +1,181 @@
+package sk.uniba.fmph.dcs.game_board;
+
+import sk.uniba.fmph.dcs.stone_age.Effect;
+import sk.uniba.fmph.dcs.stone_age.PlayerOrder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ToolMakerHutFields {
+    private PlayerOrder toolMakerFigures;
+    private PlayerOrder hutFigures;
+    private PlayerOrder fieldsFigures;
+
+    private final int restriction; // for less than 4 players
+    private static final int MIN_PL = 2;
+    private static final int MAX_PL = 4;
+
+    public ToolMakerHutFields(int players){
+        this.restriction = players;
+        if (!(MIN_PL <= players && players <= MAX_PL)){
+            throw new IllegalArgumentException("Invalid number of players");
+        }
+        toolMakerFigures = null;
+        hutFigures = null;
+        fieldsFigures = null;
+    }
+
+    private boolean checkRestrictions()
+    {
+        if(this.restriction == MAX_PL)
+            return true;
+
+        int alreadyOccupiedLocations = 0;
+
+        if(toolMakerFigures != null)
+            alreadyOccupiedLocations++;
+        if(hutFigures != null)
+            alreadyOccupiedLocations++;
+        if(fieldsFigures != null)
+            alreadyOccupiedLocations++;
+
+        if(alreadyOccupiedLocations >= 2)
+            return false;
+        return true;
+    }
+
+    public boolean canPlaceOnToolMaker(Player player){
+        if(!checkRestrictions())
+            return false;
+        return toolMakerFigures == null && player.getPlayerBoard().hasFigures(1);
+    }
+
+    public boolean placeOnToolMaker(Player player)
+    {
+        if(canPlaceOnToolMaker(player)){
+            player.getPlayerBoard().takeFigures(1);
+            toolMakerFigures = player.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean canActionOnToolMaker(Player player){
+        return toolMakerFigures.equals(player.getPlayerOrder());
+    }
+
+    public boolean actionToolMaker(Player player){
+        if (canActionOnToolMaker(player)) {
+            Collection<Effect> newTool = new ArrayList<Effect>();
+            newTool.add(Effect.TOOL);
+            player.getPlayerBoard().giveEffect(newTool);
+            toolMakerFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean skipActionOnToolMaker(Player player){
+        if (canActionOnToolMaker(player)) {
+            toolMakerFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean canPlaceOnHut(Player player){
+        if(!checkRestrictions())
+            return false;
+        return hutFigures == null  && player.getPlayerBoard().hasFigures(2);
+    }
+
+    public boolean placeOnHut(Player figures){
+        if(canPlaceOnHut(figures)){
+            figures.getPlayerBoard().takeFigures(2);
+            hutFigures = figures.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean canActionOnHut(Player player){
+        return hutFigures.equals(player.getPlayerOrder());
+    }
+
+    public boolean actionHut(Player player){
+        if (hutFigures.equals(player.getPlayerOrder())) {
+            player.getPlayerBoard().giveFigure();
+            hutFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean skipActionOnHut(Player player){
+        if (canActionOnHut(player)) {
+            hutFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean placeOnFields(Player player){
+        if(canPlaceOnFields(player)){
+            player.getPlayerBoard().takeFigures(1);
+            fieldsFigures = player.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean canPlaceOnFields(Player player)
+    {
+        if(!checkRestrictions())
+            return false;
+        return fieldsFigures == null  && player.getPlayerBoard().hasFigures(1);
+    }
+
+    public boolean canActionOnFields(Player player){
+        return toolMakerFigures.equals(player.getPlayerOrder());
+    }
+
+    public boolean actionFields(Player player){
+        if (fieldsFigures.equals(player.getPlayerOrder())) {
+            Collection<Effect> newField = new ArrayList<Effect>();
+            newField.add(Effect.FIELD);
+            player.getPlayerBoard().giveEffect(newField);
+            fieldsFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean skipActionOnFields(Player player){
+        if (canActionOnFields(player)) {
+            fieldsFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean newTurn(){
+        return toolMakerFigures == null && hutFigures == null && fieldsFigures == null;
+    }
+
+    public String state(){
+        StringBuilder state = new StringBuilder();
+        state.append("Player on Tool Maker:");
+        state.append(toolMakerFigures == null ? "None" : " " + toolMakerFigures.toString());
+        state.append("\n");
+
+        state.append("Player on Fields:");
+        state.append(fieldsFigures == null ? "None" : " " + fieldsFigures.toString());
+        state.append("\n");
+
+        state.append("Player on Hut:");
+        state.append(hutFigures == null ? "None" : " " + hutFigures.toString());
+        state.append("\n");
+
+        return state.toString();
+    }
+}

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/InterfaceFigureLocationInternal.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/InterfaceFigureLocationInternal.java
@@ -13,6 +13,6 @@ public interface InterfaceFigureLocationInternal {
                             Collection<Effect> outputResources);
     boolean skipAction(Player player);
     HasAction tryToMakeAction(Player player);
-    boolean newTurn(); //returns true if end of game is implied by
+    boolean newTurn(); //returns true if end of round is implied by
                         //given location
 }

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/InterfaceFigureLocationInternal.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/InterfaceFigureLocationInternal.java
@@ -11,8 +11,9 @@ public interface InterfaceFigureLocationInternal {
     HasAction tryToPlaceFigures(Player player, int count);
     ActionResult makeAction(Player player, Collection<Effect> inputResources,
                             Collection<Effect> outputResources);
-    boolean skipAction(Player player);
+    boolean skipAction(Player player); // returns true if player had his figures
+                                        // on location which method withdrew
     HasAction tryToMakeAction(Player player);
-    boolean newTurn(); //returns true if end of round is implied by
+    boolean newTurn(); //returns true if end of game is implied by
                         //given location
 }

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnFieldsAdaptor.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnFieldsAdaptor.java
@@ -1,0 +1,55 @@
+package sk.uniba.fmph.dcs.game_board;
+
+import sk.uniba.fmph.dcs.stone_age.ActionResult;
+import sk.uniba.fmph.dcs.stone_age.Effect;
+import sk.uniba.fmph.dcs.stone_age.HasAction;
+
+import java.util.Collection;
+
+public class PlaceOnFieldsAdaptor implements InterfaceFigureLocationInternal{
+    private ToolMakerHutFields tmhf;
+
+    public PlaceOnFieldsAdaptor(ToolMakerHutFields tmhf) {
+        this.tmhf = tmhf;
+    }
+
+    @Override
+    public boolean placeFigures(Player player, int figureCount){
+        return figureCount == 1 && tmhf.canPlaceOnFields(player);
+    }
+
+    @Override
+    public HasAction tryToPlaceFigures(Player player, int count){
+        if(!this.placeFigures(player, count))
+            return HasAction.NO_ACTION_POSSIBLE;
+        return HasAction.WAITING_FOR_PLAYER_ACTION;
+    }
+
+    @Override
+    public ActionResult makeAction(Player player, Collection<Effect> inputResources,
+                                   Collection<Effect> outputResources)
+    {
+        if(tryToMakeAction(player) == HasAction.WAITING_FOR_PLAYER_ACTION && tmhf.actionToolMaker(player))
+            return ActionResult.ACTION_DONE;
+        return ActionResult.FAILURE;
+    }
+
+
+    @Override
+    public HasAction tryToMakeAction(Player player){
+        if (tmhf.canActionOnFields(player))
+            return HasAction.WAITING_FOR_PLAYER_ACTION;
+        return HasAction.NO_ACTION_POSSIBLE;
+    }
+
+    @Override
+    public boolean skipAction(Player player){
+        return tmhf.skipActionOnFields(player);
+    }
+
+    @Override
+    public boolean newTurn()
+    {
+        return tmhf.newTurn();
+    }
+}

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnHutAdaptor.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnHutAdaptor.java
@@ -1,22 +1,21 @@
 package sk.uniba.fmph.dcs.game_board;
 
-import org.apache.commons.lang3.NotImplementedException;
 import sk.uniba.fmph.dcs.stone_age.ActionResult;
 import sk.uniba.fmph.dcs.stone_age.Effect;
 import sk.uniba.fmph.dcs.stone_age.HasAction;
 
 import java.util.Collection;
 
-public class PlaceOnToolMaker implements InterfaceFigureLocationInternal{
+public class PlaceOnHutAdaptor implements InterfaceFigureLocationInternal{
     private ToolMakerHutFields tmhf;
 
-    public PlaceOnToolMaker(ToolMakerHutFields tmhf) {
+    public PlaceOnHutAdaptor(ToolMakerHutFields tmhf) {
         this.tmhf = tmhf;
     }
 
     @Override
     public boolean placeFigures(Player player, int figureCount){
-        return figureCount == 1 && tmhf.canPlaceOnToolMaker(player);
+        return figureCount == 2 && tmhf.canPlaceOnHut(player);
     }
 
     @Override
@@ -28,7 +27,7 @@ public class PlaceOnToolMaker implements InterfaceFigureLocationInternal{
 
     @Override
     public ActionResult makeAction(Player player, Collection<Effect> inputResources,
-                            Collection<Effect> outputResources)
+                                   Collection<Effect> outputResources)
     {
         if(tryToMakeAction(player) == HasAction.WAITING_FOR_PLAYER_ACTION && tmhf.actionToolMaker(player))
             return ActionResult.ACTION_DONE;
@@ -38,14 +37,14 @@ public class PlaceOnToolMaker implements InterfaceFigureLocationInternal{
 
     @Override
     public HasAction tryToMakeAction(Player player){
-        if (tmhf.canActionOnToolMaker(player))
+        if (tmhf.canActionOnHut(player))
             return HasAction.WAITING_FOR_PLAYER_ACTION;
         return HasAction.NO_ACTION_POSSIBLE;
     }
 
     @Override
     public boolean skipAction(Player player){
-        return tmhf.skipActionOnToolMaker(player);
+        return tmhf.skipActionOnHut(player);
     }
 
     @Override

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnToolMaker.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnToolMaker.java
@@ -1,0 +1,55 @@
+package sk.uniba.fmph.dcs.game_board;
+
+import org.apache.commons.lang3.NotImplementedException;
+import sk.uniba.fmph.dcs.stone_age.ActionResult;
+import sk.uniba.fmph.dcs.stone_age.Effect;
+import sk.uniba.fmph.dcs.stone_age.HasAction;
+
+import java.util.Collection;
+
+public class PlaceOnToolMaker implements InterfaceFigureLocationInternal{
+    private ToolMakerHutFields tmhf;
+
+    public PlaceOnToolMaker(ToolMakerHutFields tmhf) {
+        this.tmhf = tmhf;
+    }
+
+    @Override
+    public boolean placeFigures(Player player, int figureCount){
+        return figureCount == 1 && tmhf.canPlaceOnToolMaker(player);
+    }
+
+    @Override
+    public HasAction tryToPlaceFigures(Player player, int count){
+        if(!this.placeFigures(player, count))
+            return HasAction.NO_ACTION_POSSIBLE;
+        return HasAction.WAITING_FOR_PLAYER_ACTION;
+    }
+
+    @Override
+    public ActionResult makeAction(Player player, Collection<Effect> inputResources,
+                            Collection<Effect> outputResources)
+    {
+        if(tryToMakeAction(player) == HasAction.WAITING_FOR_PLAYER_ACTION && tmhf.actionToolMaker(player))
+            return ActionResult.ACTION_DONE;
+        return ActionResult.FAILURE;
+    }
+
+    @Override
+    public HasAction tryToMakeAction(Player player){
+        if (tmhf.canActionOnToolMaker(player))
+            return HasAction.WAITING_FOR_PLAYER_ACTION;
+        return HasAction.NO_ACTION_POSSIBLE;
+    }
+
+    public boolean skipAction(Player player){
+        throw new NotImplementedException("Skip action not implemented");
+    }
+
+
+    public boolean newTurn() //returns true if end of round is implied by
+                        //given location
+    {
+        return tmhf.newTurn();
+    }
+}

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnToolMaker.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnToolMaker.java
@@ -35,6 +35,7 @@ public class PlaceOnToolMaker implements InterfaceFigureLocationInternal{
         return ActionResult.FAILURE;
     }
 
+
     @Override
     public HasAction tryToMakeAction(Player player){
         if (tmhf.canActionOnToolMaker(player))
@@ -42,13 +43,13 @@ public class PlaceOnToolMaker implements InterfaceFigureLocationInternal{
         return HasAction.NO_ACTION_POSSIBLE;
     }
 
+    @Override
     public boolean skipAction(Player player){
-        throw new NotImplementedException("Skip action not implemented");
+        return tmhf.skipActionOnToolMaker(player);
     }
 
-
-    public boolean newTurn() //returns true if end of round is implied by
-                        //given location
+    @Override
+    public boolean newTurn()
     {
         return tmhf.newTurn();
     }

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnToolMakerAdaptor.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/PlaceOnToolMakerAdaptor.java
@@ -1,0 +1,55 @@
+package sk.uniba.fmph.dcs.game_board;
+
+import sk.uniba.fmph.dcs.stone_age.ActionResult;
+import sk.uniba.fmph.dcs.stone_age.Effect;
+import sk.uniba.fmph.dcs.stone_age.HasAction;
+
+import java.util.Collection;
+
+public class PlaceOnToolMakerAdaptor implements InterfaceFigureLocationInternal{
+    private ToolMakerHutFields tmhf;
+
+    public PlaceOnToolMakerAdaptor(ToolMakerHutFields tmhf) {
+        this.tmhf = tmhf;
+    }
+
+    @Override
+    public boolean placeFigures(Player player, int figureCount){
+        return figureCount == 1 && tmhf.canPlaceOnToolMaker(player);
+    }
+
+    @Override
+    public HasAction tryToPlaceFigures(Player player, int count){
+        if(!this.placeFigures(player, count))
+            return HasAction.NO_ACTION_POSSIBLE;
+        return HasAction.WAITING_FOR_PLAYER_ACTION;
+    }
+
+    @Override
+    public ActionResult makeAction(Player player, Collection<Effect> inputResources,
+                            Collection<Effect> outputResources)
+    {
+        if(tryToMakeAction(player) == HasAction.WAITING_FOR_PLAYER_ACTION && tmhf.actionToolMaker(player))
+            return ActionResult.ACTION_DONE;
+        return ActionResult.FAILURE;
+    }
+
+
+    @Override
+    public HasAction tryToMakeAction(Player player){
+        if (tmhf.canActionOnToolMaker(player))
+            return HasAction.WAITING_FOR_PLAYER_ACTION;
+        return HasAction.NO_ACTION_POSSIBLE;
+    }
+
+    @Override
+    public boolean skipAction(Player player){
+        return tmhf.skipActionOnToolMaker(player);
+    }
+
+    @Override
+    public boolean newTurn()
+    {
+        return tmhf.newTurn();
+    }
+}

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/Player.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/Player.java
@@ -1,5 +1,6 @@
 package sk.uniba.fmph.dcs.game_board;
 
+import sk.uniba.fmph.dcs.stone_age.InterfacePlayerBoardGameBoard;
 import sk.uniba.fmph.dcs.stone_age.PlayerOrder;
 
 public final class Player {

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
@@ -25,7 +25,7 @@ public class ToolMakerHutFields {
         fieldsFigures = null;
     }
 
-    private boolean checkRestriction()
+    private boolean checkRestrictions()
     {
         if(this.restriction == MAX_PL)
             return true;
@@ -45,17 +45,9 @@ public class ToolMakerHutFields {
     }
 
     public boolean canPlaceOnToolMaker(Player player){
-        if(!checkRestriction())
+        if(!checkRestrictions())
             return false;
         return toolMakerFigures == null && player.getPlayerBoard().hasFigures(1);
-    }
-    public boolean placeOnHut(Player figures){
-        if(canPlaceOnHut(figures)){
-            figures.getPlayerBoard().takeFigures(2);
-            hutFigures = figures.getPlayerOrder();
-            return true;
-        }
-        return false;
     }
 
     public boolean placeOnToolMaker(Player player)
@@ -83,6 +75,34 @@ public class ToolMakerHutFields {
         return false;
     }
 
+    public boolean skipActionOnToolMaker(Player player){
+        if (canActionOnToolMaker(player)) {
+            player.getPlayerBoard().giveFigure();
+            toolMakerFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+    boolean canPlaceOnHut(Player player){
+        if(!checkRestrictions())
+            return false;
+        return hutFigures == null  && player.getPlayerBoard().hasFigures(2);
+    }
+
+    public boolean placeOnHut(Player figures){
+        if(canPlaceOnHut(figures)){
+            figures.getPlayerBoard().takeFigures(2);
+            hutFigures = figures.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean canActionOnHut(Player player){
+        return hutFigures.equals(player.getPlayerOrder());
+    }
+
     public boolean actionHut(Player player){
         if (hutFigures.equals(player.getPlayerOrder())) {
             player.getPlayerBoard().giveFigure();
@@ -91,11 +111,17 @@ public class ToolMakerHutFields {
         }
         return false;
     }
-    boolean canPlaceOnHut(Player player){
-        if(!checkRestriction())
-            return false;
-        return hutFigures == null  && player.getPlayerBoard().hasFigures(2);
+
+    public boolean skipActionOnHut(Player player){
+        if (canActionOnHut(player)) {
+            player.getPlayerBoard().giveFigure();
+            player.getPlayerBoard().giveFigure();
+            hutFigures = null;
+            return true;
+        }
+        return false;
     }
+
     public boolean placeOnFields(Player player){
         if(canPlaceOnFields(player)){
             player.getPlayerBoard().takeFigures(1);
@@ -103,6 +129,17 @@ public class ToolMakerHutFields {
             return true;
         }
         return false;
+    }
+
+    public boolean canPlaceOnFields(Player player)
+    {
+        if(!checkRestrictions())
+            return false;
+        return fieldsFigures == null  && player.getPlayerBoard().hasFigures(1);
+    }
+
+    public boolean canActionOnFields(Player player){
+        return toolMakerFigures.equals(player.getPlayerOrder());
     }
 
     public boolean actionFields(Player player){
@@ -115,12 +152,16 @@ public class ToolMakerHutFields {
         }
         return false;
     }
-    public boolean canPlaceOnFields(Player player)
-    {
-        if(!checkRestriction())
-            return false;
-        return fieldsFigures == null  && player.getPlayerBoard().hasFigures(1);
+
+    public boolean skipActionOnFields(Player player){
+        if (canActionOnFields(player)) {
+            player.getPlayerBoard().giveFigure();
+            fieldsFigures = null;
+            return true;
+        }
+        return false;
     }
+
     public boolean newTurn(){
         return toolMakerFigures == null && hutFigures == null && fieldsFigures == null;
     }

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
@@ -44,27 +44,6 @@ public class ToolMakerHutFields {
         return true;
     }
 
-    public boolean placeOnToolMaker(Player player)
-    {
-        if(canPlaceOnToolMaker(player)){
-            player.getPlayerBoard().takeFigures(1);
-            toolMakerFigures = player.getPlayerOrder();
-            return true;
-        }
-        return false;
-    }
-    public boolean actionToolMaker(Player player){
-        if (toolMakerFigures.equals(player.getPlayerOrder())) {
-            Collection<Effect> newTool = new ArrayList<Effect>();
-            newTool.add(Effect.TOOL);
-            player.getPlayerBoard().giveEffect(newTool);
-            toolMakerFigures = null;
-            return true;
-        }
-        return false;
-    }
-
-
     public boolean canPlaceOnToolMaker(Player player){
         if(!checkRestriction())
             return false;
@@ -78,6 +57,32 @@ public class ToolMakerHutFields {
         }
         return false;
     }
+
+    public boolean placeOnToolMaker(Player player)
+    {
+        if(canPlaceOnToolMaker(player)){
+            player.getPlayerBoard().takeFigures(1);
+            toolMakerFigures = player.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean canActionOnToolMaker(Player player){
+        return toolMakerFigures.equals(player.getPlayerOrder());
+    }
+
+    public boolean actionToolMaker(Player player){
+        if (canActionOnToolMaker(player)) {
+            Collection<Effect> newTool = new ArrayList<Effect>();
+            newTool.add(Effect.TOOL);
+            player.getPlayerBoard().giveEffect(newTool);
+            toolMakerFigures = null;
+            return true;
+        }
+        return false;
+    }
+
     public boolean actionHut(Player player){
         if (hutFigures.equals(player.getPlayerOrder())) {
             player.getPlayerBoard().giveFigure();
@@ -99,6 +104,7 @@ public class ToolMakerHutFields {
         }
         return false;
     }
+
     public boolean actionFields(Player player){
         if (fieldsFigures.equals(player.getPlayerOrder())) {
             Collection<Effect> newField = new ArrayList<Effect>();

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
@@ -1,0 +1,141 @@
+package sk.uniba.fmph.dcs.game_board;
+
+import sk.uniba.fmph.dcs.stone_age.Effect;
+import sk.uniba.fmph.dcs.stone_age.Location;
+import sk.uniba.fmph.dcs.stone_age.PlayerOrder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class ToolMakerHutFields {
+    private PlayerOrder toolMakerFigures;
+    private PlayerOrder hutFigures;
+    private PlayerOrder fieldsFigures;
+
+    private final int restriction; // for less than 4 players
+    private static final int MIN_PL = 2;
+    private static final int MAX_PL = 4;
+
+    public ToolMakerHutFields(int players){
+        this.restriction = players;
+        if (!(MIN_PL <= players && players <= MAX_PL)){
+            throw new IllegalArgumentException("Invalid number of players");
+        }
+        toolMakerFigures = null;
+        hutFigures = null;
+        fieldsFigures = null;
+    }
+
+    private boolean checkRestriction()
+    {
+        if(this.restriction == MAX_PL)
+            return true;
+
+        int alreadyOccupiedLocations = 0;
+
+        if(toolMakerFigures != null)
+            alreadyOccupiedLocations++;
+        if(hutFigures != null)
+            alreadyOccupiedLocations++;
+        if(fieldsFigures != null)
+            alreadyOccupiedLocations++;
+
+        if(alreadyOccupiedLocations >= 2)
+            return false;
+        return true;
+    }
+
+    public boolean placeOnToolMaker(Player player)
+    {
+        if(canPlaceOnToolMaker(player)){
+            player.getPlayerBoard().takeFigures(1);
+            toolMakerFigures = player.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+    public boolean actionToolMaker(Player player){
+        if (toolMakerFigures.equals(player.getPlayerOrder())) {
+            Collection<Effect> newTool = new ArrayList<Effect>();
+            newTool.add(Effect.TOOL);
+            player.getPlayerBoard().giveEffect(newTool);
+            toolMakerFigures = null;
+            return true;
+        }
+        return false;
+    }
+
+
+    public boolean canPlaceOnToolMaker(Player player){
+        if(!checkRestriction())
+            return false;
+        return toolMakerFigures == null && player.getPlayerBoard().hasFigures(1);
+    }
+    public boolean placeOnHut(Player figures){
+        if(canPlaceOnHut(figures)){
+            figures.getPlayerBoard().takeFigures(2);
+            hutFigures = figures.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+    public boolean actionHut(Player player){
+        if (hutFigures.equals(player.getPlayerOrder())) {
+            player.getPlayerBoard().giveFigure();
+            hutFigures = null;
+            return true;
+        }
+        return false;
+    }
+    boolean canPlaceOnHut(Player player){
+        if(!checkRestriction())
+            return false;
+        return hutFigures == null  && player.getPlayerBoard().hasFigures(2);
+    }
+    public boolean placeOnFields(Player player){
+        if(canPlaceOnFields(player)){
+            player.getPlayerBoard().takeFigures(1);
+            fieldsFigures = player.getPlayerOrder();
+            return true;
+        }
+        return false;
+    }
+    public boolean actionFields(Player player){
+        if (fieldsFigures.equals(player.getPlayerOrder())) {
+            Collection<Effect> newField = new ArrayList<Effect>();
+            newField.add(Effect.FIELD);
+            player.getPlayerBoard().giveEffect(newField);
+            fieldsFigures = null;
+            return true;
+        }
+        return false;
+    }
+    public boolean canPlaceOnFields(Player player)
+    {
+        if(!checkRestriction())
+            return false;
+        return fieldsFigures == null  && player.getPlayerBoard().hasFigures(1);
+    }
+    public boolean newTurn(){
+        return toolMakerFigures == null && hutFigures == null && fieldsFigures == null;
+    }
+
+    public String state(){
+        StringBuilder state = new StringBuilder();
+        state.append("Player on Tool Maker:");
+        state.append(toolMakerFigures == null ? "None" : " " + toolMakerFigures.toString());
+        state.append("\n");
+
+        state.append("Player on Fields:");
+        state.append(fieldsFigures == null ? "None" : " " + fieldsFigures.toString());
+        state.append("\n");
+
+        state.append("Player on Hut:");
+        state.append(hutFigures == null ? "None" : " " + hutFigures.toString());
+        state.append("\n");
+
+        return state.toString();
+    }
+}

--- a/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
+++ b/src/main/java/sk/uniba/fmph/dcs/game_board/ToolMakerHutFields.java
@@ -1,13 +1,10 @@
 package sk.uniba.fmph.dcs.game_board;
 
 import sk.uniba.fmph.dcs.stone_age.Effect;
-import sk.uniba.fmph.dcs.stone_age.Location;
 import sk.uniba.fmph.dcs.stone_age.PlayerOrder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 public class ToolMakerHutFields {
     private PlayerOrder toolMakerFigures;

--- a/src/main/java/sk/uniba/fmph/dcs/stone_age/CivilisationCard.java
+++ b/src/main/java/sk/uniba/fmph/dcs/stone_age/CivilisationCard.java
@@ -1,6 +1,8 @@
 package sk.uniba.fmph.dcs.stone_age;
 
+import java.util.Collection;
+
 public class CivilisationCard {
-    Collection<ImmediateEffectType> immediateEffect;
-    Collection<EndOfGameEffectType> endOfGameEffect;
+    Collection<ImmediateEffect> immediateEffect;
+    Collection<EndOfGameEffect> endOfGameEffect;
 }

--- a/src/main/java/sk/uniba/fmph/dcs/stone_age/InterfaceFigureLocation.java
+++ b/src/main/java/sk/uniba/fmph/dcs/stone_age/InterfaceFigureLocation.java
@@ -7,7 +7,8 @@ public interface InterfaceFigureLocation {
     HasAction tryToPlaceFigures(PlayerOrder player, int count);
     ActionResult makeAction(PlayerOrder player, Collection<Effect> inputResources,
                             Collection<Effect> outputResources);
-    boolean skipAction(PlayerOrder player);
+    boolean skipAction(PlayerOrder player);// returns true if player had his figures
+                                            // on location which method withdrew
     HasAction tryToMakeAction(PlayerOrder player);
     boolean newTurn(); //returns true if end of game is implied by
                         //given location

--- a/src/main/java/sk/uniba/fmph/dcs/stone_age/InterfacePlayerBoardGameBoard.java
+++ b/src/main/java/sk/uniba/fmph/dcs/stone_age/InterfacePlayerBoardGameBoard.java
@@ -6,6 +6,7 @@ import java.util.OptionalInt;
 public interface InterfacePlayerBoardGameBoard {
     void giveEffect(Collection<Effect> stuff);
     void giveEndOfGameEffect(Collection<EndOfGameEffect> stuff);
+    void giveFigure();
     boolean takeResources(Collection<Effect> stuff);
     boolean takeFigures(int count);
     boolean hasFigures(int count);


### PR DESCRIPTION
Edited ToolMakerHutFields methods set by adding canActionOn<Hut,Fields,ToolMaker> and skipActionOn<Hut,Fields,ToolMaker> to generalize implementation of PlaceOn<Hut,Fields,ToolMaker>Adaptor classes.